### PR TITLE
Make JS comply with Airbnb standard

### DIFF
--- a/_build.js
+++ b/_build.js
@@ -8,38 +8,6 @@ const glob = require('glob');
 const autoprefixer = require('autoprefixer');
 const config = require('./_config.js');
 
-glob(path.resolve(__dirname, '*.+(scss|sass)'), (err, files) => {
-  if (err) {
-    return console.log(err);
-  }
-
-  files.forEach(file => {
-    sass.render(Object.assign({}, config.sass, { file }), (err, result) => {
-      if (err) {
-        return console.log(err);
-      }
-
-      postcss()
-        .use(autoprefixer(config.autoprefixer))
-        .process(result.css)
-        .then(result => {
-          const dest = getDestPath(file);
-
-          fs.writeFile(dest, result.css, err => {
-            if (err) {
-              return console.log(err);
-            }
-
-            const srcRelative = path.relative(process.cwd(), file);
-            const destRelative = path.relative(process.cwd(), dest);
-
-            console.log(`Sass compiled! ${srcRelative} => ${destRelative}`);
-          })
-        });
-    });
-  });
-});
-
 /**
  * Returns the resolved output file path for the compiled stylesheets
  * @return {String} The destination dir
@@ -59,3 +27,44 @@ function getDestPath(file) {
 
   return path.resolve(destDir, `${filename}.css`);
 }
+
+// Looks for each SCSS or Sass file
+glob(path.resolve(__dirname, '*.+(scss|sass)'), (err, files) => {
+  if (err) {
+    console.log(err);
+    return;
+  }
+
+  files.forEach(file => {
+    sass.render(Object.assign({}, config.sass, { file }), (renderErr, result) => {
+      if (renderErr) {
+        console.log(renderErr);
+        return;
+      }
+
+      postcss()
+        .use(autoprefixer(config.autoprefixer))
+        .process(result.css)
+        .then(processedResult => {
+          const dest = getDestPath(file);
+
+          fs.writeFile(dest, processedResult.css, writeErr => {
+            if (writeErr) {
+              console.log(writeErr);
+              return;
+            }
+
+            const srcRelative = path.relative(process.cwd(), file);
+            const destRelative = path.relative(process.cwd(), dest);
+
+            console.log(`Sass compiled! ${srcRelative} => ${destRelative}`);
+            return;
+          });
+        });
+
+      return;
+    });
+  });
+
+  return;
+});

--- a/_config.js
+++ b/_config.js
@@ -4,11 +4,11 @@ exports.sass = {
   includePath: __dirname,
   outputStyle: 'compressed',
   sourceMap: true,
-  sourceMapEmbed: true
+  sourceMapEmbed: true,
 };
 
 // Autoprefixer options
 // https://github.com/postcss/autoprefixer#options
 exports.autoprefixer = {
-  browsers: '> 5%'
+  browsers: '> 5%',
 };


### PR DESCRIPTION
Moved the `getDestPath` function declaration to the top.
Renamed some potentially clashing variable names.
Added consistent return values.
Added small syntax fixes like trailing commas.
