### PR TITLE
Deprecate setcolor; introduce getcolor in its stead with a warning.

### DIFF
--- a/base/_defaults.scss
+++ b/base/_defaults.scss
@@ -33,7 +33,7 @@ a {
 	text-decoration: none;
 	&:hover,
 	&:focus {
-		color: setcolor(gray);
+		color: getcolor(gray);
 	}
 	&:focus {
 		outline: none;

--- a/pages/_sample-page.scss
+++ b/pages/_sample-page.scss
@@ -38,7 +38,7 @@
 	max-width: 600px;
 	margin: rem(0 10px 40px);
 	padding: rem(0 40px 40px);
-	border: 1px solid rgba(setcolor(black), .2);
+	border: 1px solid rgba(getcolor(black), .2);
 	border-radius: rem(5px);
 	overflow: hidden;
 	@include mq(small) {
@@ -51,7 +51,7 @@
 		width: calc(100% + 80px);
 		left: rem(-40px);
 		padding: rem(10px 40px);
-		background: setcolor(black);
+		background: getcolor(black);
 		color: #fff;
 		font-family: 'Open Sans', sans-serif;
 		font-weight: 700;
@@ -135,14 +135,14 @@
 	}
 	.row {
 		@include container(1200px);
-		background: rgba(setcolor(black), .1);
+		background: rgba(getcolor(black), .1);
 		padding: rem(0 20px);
 		margin-bottom: rem(50px);
 	}
 	div,
 	aside,
 	article {
-		background: rgba(setcolor(black), .4);
+		background: rgba(getcolor(black), .4);
 		padding: rem(20px);
 		margin-bottom: rem(20px);
 		color: #fff;

--- a/settings/_colors.scss
+++ b/settings/_colors.scss
@@ -7,43 +7,16 @@
 // --------------------------------
 
 $colors: (
-	black: #2C3E50,
-	white: #fff,
-	gray: (
-		base: #999,
-		light: #ccc,
-		dark: #333
-	),
-	teal: (
-		base: #139397,
-		light: #33afb3,
-		dark: #264d4e
-	)
+  black: #2C3E50,
+  white: #fff,
+  gray: (
+    base: #999,
+    light: #ccc,
+    dark: #333
+  ),
+  teal: (
+    base: #139397,
+    light: #33afb3,
+    dark: #264d4e
+  )
 );
-
-
-// --------------------------------
-// setcolor() Function
-// --------------------------------
-
-/*
- * Returns a color with an optional tone from the map
- *
- * @param {string}  $color_name     The base name of the color
- * @param {tone}    ($tone|'base')  The tone of that color or 'base'
- *
- * @return {string} The matching color's value from the map
- */
-
-@function setcolor($color_name, $tone: base) {
-	@if map-has-key($colors, $color_name) {
-		$map_color_name: map-get($colors, $color_name);
-		@if (length($map_color_name) > 1) { /* This must be a map */
-			@return map-get($map_color_name, $tone);
-		} @else { /* It's just a single color */
-			@return $map_color_name;
-		}
-	} @else {
-		@warn "Couldn't find a color named `#{$color_name}`.";
-	}
-}

--- a/utils/_all.scss
+++ b/utils/_all.scss
@@ -1,3 +1,4 @@
+@import "functions/all";
 @import "fonts";
 @import "mixins/all";
 @import "utilities";

--- a/utils/functions/_all.scss
+++ b/utils/functions/_all.scss
@@ -1,0 +1,1 @@
+@import 'getcolor';

--- a/utils/functions/_getcolor.scss
+++ b/utils/functions/_getcolor.scss
@@ -1,0 +1,34 @@
+/**
+ * Returns a color with an optional tone from the map
+ *
+ * @param {string}  $color_name     The base name of the color
+ * @param {tone}    ($tone|'base')  The tone of that color or 'base'
+ *
+ * @return {string} The matching color's value from the map
+ */
+
+@function getcolor($color-name, $tone: base) {
+  @if map-has-key($colors, $color-name) {
+    $map-color-name: map-get($colors, $color_name);
+    @if (length($map-color-name) > 1) {
+      // This must be a map
+      @return map-get($map-color-name, $tone);
+    } @else {
+      // It's just a single color
+      @return $map-color-name;
+    }
+  } @else {
+    @warn "Couldn't find a color named `#{$color-name}`.";
+  }
+}
+
+
+/**
+ * Alias for getcolor to allow transitions for older codebases
+ * @deprecated
+ */
+@function setcolor($color_name, $tone: base) {
+  @warn '`setcolor` is deprecated and will be removed in a future release!';
+
+  @return getcolor($color-name, $tone);
+}

--- a/utils/functions/_getcolor.scss
+++ b/utils/functions/_getcolor.scss
@@ -28,7 +28,7 @@
  * @deprecated
  */
 @function setcolor($color_name, $tone: base) {
-  @warn '`setcolor` is deprecated and will be removed in a future release!';
+  @warn '`setcolor` is deprecated and will be removed in a future release! Use `getcolor` instead.';
 
   @return getcolor($color-name, $tone);
 }


### PR DESCRIPTION
Changes the `setcolor` function to `getcolor`.

Adds an alias for the old function that throws a deprecation warning during compile:
`WARNING: `setcolor` is deprecated and will be removed in a future release!
Backtrace:
    utils/functions/_getcolor.scss:31, in function `setcolor`
    pages/_sample-page.scss:145`

As a side-effect, this introduces a `utils/_all.scss` to include it. This file does not yet actually include all of the files in that directory.
