### PR TITLE
Add flag for strict mode to satiate Node 5.

### DIFF
--- a/_build.js
+++ b/_build.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const sass = require('node-sass');


### PR DESCRIPTION
Runs in strict mode to avoid a nasty node error:

```
  let renderedMessage = ' ERROR '.error.errorBg;
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:139:18)
    at node.js:999:3
```
