### PR TITLE
Updating placeholder to not use :-moz-placeholder (deprecated since F…

### DIFF
--- a/core/_placeholder.scss
+++ b/core/_placeholder.scss
@@ -8,13 +8,13 @@
   &::-webkit-input-placeholder {
     @content;
   }
-  &:-moz-placeholder {
-    @content;
-  }
   &::-moz-placeholder {
     @content;
   }
   &:-ms-input-placeholder {
+    @content;
+  }
+  &::placeholder {
     @content;
   }
 }


### PR DESCRIPTION
Updating to use the newer forms of placeholder for Firefox and removing the older version:

> Note: The ::-moz-placeholder pseudo-element was introduced as a replacement for the :-moz-placeholder pseudo-class that has been deprecated in Firefox 19. Since Firefox 51 this feature is implemented as the standard ::placeholder pseudo-element.

https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder